### PR TITLE
Fix plugin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+/docs/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [full API docs](./docs/i18nlint-common.md) for more information.
 
 ## License
 
-Copyright © 2022, JEDLSoft
+Copyright © 2022-2023, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ limitations under the License.
 
 - update the plugin to return only classes, as the linter may need to instantiate
   the classes multiple times
+- add the getRuleSets() method to the plugin to allow the plugins to define
+  standard rule sets
 
 ### v1.1.0
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.2.0
+
+- update the plugin to return only classes, as the linter may need to instantiate
+  the classes multiple times
+
 ### v1.1.0
 
 - added methods to abstract classes needed for loading and testing the plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i18nlint-common",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "module": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -25,8 +25,11 @@ class Formatter {
     /**
      * Construct an formatter instance. Formatters and formatter plugins
      * should implement this abstract class.
+     *
+     * @param {Object|undefined} options options for this instance of the
+     * formatter from the config file, if any
      */
-    constructor() {
+    constructor(options) {
         if (this.constructor === Formatter) {
             throw new Error("Cannot instantiate abstract class Formatter!");
         }

--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -1,7 +1,7 @@
 /*
  * Formatter.js - Formats result output
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,7 +1,7 @@
 /*
  * Parser.js - common SPI for parser plugins
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -51,6 +51,16 @@ class Parser {
     }
 
     /**
+     * Return a description of what this parser does and what kinds of files it
+     * handles for users who are trying to discover whether or not to use it.
+     *
+     * @returns {String} a description of this parser.
+     */
+    getDescription() {
+        return this.description;
+    }
+
+    /**
      * Return the list of extensions of the files that this parser handles.
      * The extensions are listed without the dot. eg. ["json", "jsn"].
      * Subclasses should assign `this.extensions` in their constructor.

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -24,6 +24,9 @@
 class Parser {
     /**
      * Construct a new plugin.
+     *
+     * @param {Object|undefined} options options for this instance of the
+     * parser from the config file, if any
      */
     constructor(options) {
         if (this.constructor === Parser) {

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -23,7 +23,8 @@
  */
 class Plugin {
     /**
-     * Construct a new plugin.
+     * Construct a new plugin. The options can vary depending on the
+     * the plugin.
      */
     constructor(options) {
         if (this.constructor === Plugin) {
@@ -32,35 +33,19 @@ class Plugin {
     }
 
     /**
-     * Initialize the current plugin,
+     * Initialize the current plugin, if necessary.
+     *
      * @abstract
      */
     init() {}
 
     /**
-     * Return the type of this plugin. This can be one of the
-     * following:
+     * For a "rule" type of plugin, this returns a list of Rule classes
+     * that this plugin implements. Note this is the class, not an
+     * instance of the class. The linter may need to instantiate this
+     * rule multiple times.
      *
-     * <ul>
-     * <li>rule - this plugin implements a new rules
-     * <li>parser - this plugin knows how to parse files more deeply
-     * than line-by-line
-     * <li>formatter - this plugin formats results for a particular
-     * type of output
-     * </ul>
-     *
-     * @returns {String} tells what type of plugin this is
-     * @abstract
-     */
-    getType() {
-        return this.type;
-    }
-
-    /**
-     * For a "rule" type of plugin, this returns a list of Rule instances
-     * that this plugin implements.
-     *
-     * @returns {Array.<Rule>} list of Rule instances implemented by this
+     * @returns {Array.<Class>} list of Rule classes implemented by this
      * plugin
      */
     getRules() {
@@ -69,12 +54,11 @@ class Plugin {
 
     /**
      * For a "parser" type of plugin, this returns a list of Parser classes
-     * that this plugin implements. Note that the other methods return
-     * instances of rules and formatters, but this method returns the class
-     * itself, as the ilib-lint tool needs to instantiate it multiple times,
-     * once for each file it is parsing.
+     * that this plugin implements. Note this is the class, not an
+     * instance of the class. The linter may need to instantiate this
+     * parser multiple times.
      *
-     * @returns {Array.<Parser>} list of Parser classes implemented by this
+     * @returns {Array.<Class>} list of Parser classes implemented by this
      * plugin
      */
     getParsers() {
@@ -83,9 +67,11 @@ class Plugin {
 
     /**
      * For a "formatter" type of plugin, this returns a list of Formatter
-     * instances that this plugin implements.
+     * classes that this plugin implements. Note this is the class, not an
+     * instance of the class. The linter may need to instantiate this
+     * formatter multiple times.
      *
-     * @returns {Array.<Formatter>} list of Formatter instances implemented by this
+     * @returns {Array.<Class>} list of Formatter classes implemented by this
      * plugin
      */
     getFormatters() {

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,7 +1,7 @@
 /*
  * Plugin.js - common SPI that all plugins must implement
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -40,16 +40,47 @@ class Plugin {
     init() {}
 
     /**
-     * For a "rule" type of plugin, this returns a list of Rule classes
-     * that this plugin implements. Note this is the class, not an
-     * instance of the class. The linter may need to instantiate this
-     * rule multiple times.
+     * For a plugin that implements rules, this returns a list of Rule
+     * classes that this plugin implements. Note this is the class itself,
+     * not an instance of the class. The linter may need to instantiate
+     * this rule multiple times with different optional parameters.
      *
      * @returns {Array.<Class>} list of Rule classes implemented by this
      * plugin
      */
     getRules() {
         return [];
+    }
+
+    /**
+     * Return a number of pre-defined rule sets. The idea behind this
+     * method is that the plugin can define sets of rules that users of
+     * the plugin can rely on. As the plugin
+     * developer adds new rules in their plugin, they can also update
+     * the rule set to include those new rules and users of this plugin
+     * will get enhanced functionality automatically without changing
+     * their own configuration.
+     *
+     * For example, if there is a plugin named
+     * "android", the plugin writer can add support for Java, Kotlin,
+     * and properties files in the same plugin by adding parsers and rules
+     * for each file type. They can then also add rulesets called "java",
+     * "kotlin" and "properties" which will apply all the rules from this
+     * plugin that are appropriate for the file types.
+     *
+     * By convention, these rulesets are named the same as the file type
+     * that they support, but this is not a strict requirement. Plugin
+     * writers should document the rulesets that the plugin supports in
+     * the README.md for that plugin so that users know that it is available.
+     *
+     * @returns {Object} an object where the properties are the names of
+     * rulesets and the values are objects that configure a ruleset. The
+     * properties of this subobject are the names of the rules and the
+     * values are the optional parameters for the rule, or "true" to indicate
+     * that the rule should be turned on for this set.
+     */
+    getRuleSets() {
+        return {};
     }
 
     /**

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -25,6 +25,9 @@ class Rule {
     /**
      * Construct an ilib-lint rule. Rules in plugins should implement this
      * abstract class.
+     *
+     * @param {Object|undefined} options options for this instance of the
+     * rule from the config file, if any
      */
     constructor(options) {
         if (this.constructor === Rule) {

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -1,7 +1,7 @@
 /*
  * Rule.js - Represent an ilib-lint rule
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testParser.js
+++ b/test/testParser.js
@@ -1,7 +1,7 @@
 /*
  * testParser.js - test the parser superclass object
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testParser.js
+++ b/test/testParser.js
@@ -24,6 +24,7 @@ class MockParser extends Parser {
         super();
         this.name = "mock";
         this.extensions = [ "x", "y", "z" ];
+        this.description = "A mock parser that doesn't really do a whole heck of a lot of anything.";
     }
 }
 
@@ -50,7 +51,6 @@ export const testParser = {
         test.done();
     },
 
-
     testParserGetName: function(test) {
         test.expect(2);
 
@@ -61,6 +61,20 @@ export const testParser = {
         test.ok(parser);
 
         test.equal(parser.getName(), "mock");
+
+        test.done();
+    },
+
+    testParserGetDescription: function(test) {
+        test.expect(2);
+
+        const parser = new MockParser({
+            filePath: "a/b/c.x"
+        });
+
+        test.ok(parser);
+
+        test.equal(parser.getDescription(), "A mock parser that doesn't really do a whole heck of a lot of anything.");
 
         test.done();
     },

--- a/test/testPlugin.js
+++ b/test/testPlugin.js
@@ -1,7 +1,7 @@
 /*
  * testPlugin.js - test the plugin superclass object
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testPlugin.js
+++ b/test/testPlugin.js
@@ -60,6 +60,20 @@ export const testPlugin = {
         test.done();
     },
 
+    testPluginGetRuleSetsDefault: function(test) {
+        test.expect(3);
+
+        const plugin = new MockPlugin();
+
+        test.ok(plugin);
+
+        const sets = plugin.getRuleSets();
+        test.ok(sets);
+        test.deepEqual(sets, {});
+
+        test.done();
+    },
+
     testPluginGetFormattersDefault: function(test) {
         test.expect(3);
 

--- a/test/testPlugin.js
+++ b/test/testPlugin.js
@@ -22,7 +22,6 @@ import Plugin from '../src/Plugin.js';
 class MockPlugin extends Plugin {
     constructor() {
         super();
-        this.type = "resource";
     }
 }
 
@@ -43,18 +42,6 @@ export const testPlugin = {
         test.throws(() => {
             new Plugin();
         });
-
-        test.done();
-    },
-
-    testPluginGetType: function(test) {
-        test.expect(2);
-
-        const plugin = new MockPlugin();
-
-        test.ok(plugin);
-
-        test.equal(plugin.getType(), "resource");
 
         test.done();
     },


### PR DESCRIPTION
- update the plugin to return only classes instead of instances, as the linter may need to instantiate the classes multiple times with different options
- add the getRuleSets() method to the plugin to allow the plugins to define standard rule sets
