### PR TITLE
Added Rule.getLink() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.3.0
+
+- added getLink() method to the Rule class
+
 ### v1.2.0
 
 - update the plugin to return only classes, as the linter may need to instantiate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i18nlint-common",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "module": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -65,6 +65,16 @@ class Rule {
     }
 
     /**
+     * Return the optional web link that gives more complete explanation about the Rule
+     * and how to resolve the problem.
+     *
+     * @returns {String} an URL to a web page that explains the problem this rule checks for
+     */
+    getLink() {
+        return this.link;
+    }
+
+    /**
      * Return the type of this rule. Rules can be organized into the following
      * types:
      *

--- a/test/testRule.js
+++ b/test/testRule.js
@@ -24,6 +24,7 @@ class MockRule extends Rule {
         super(options);
         this.name = "mock";
         this.description = "asdf asdf";
+        this.link = "https://github.com/docs/rule.md";
     }
 }
 
@@ -108,6 +109,19 @@ export const testRule = {
         test.equal(rule.getRuleType(), "line");
 
         test.done();
+    },
+
+    testRuleGetLink: function(test) {
+        test.expect(2);
+
+        const rule = new MockRule();
+
+        test.ok(rule);
+
+        test.equal(rule.getLink(), "https://github.com/docs/rule.md");
+
+        test.done();
     }
+
 };
 


### PR DESCRIPTION
Just another field that rules can define that allows the rule creator to give a more full explanation of the problem.