### PR TITLE
Fix: could not create a Result instance with a lineNumber equal to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v2.0.1
+
+- fix a problem where you could not create a Result instance with a
+  lineNumber equal to 0.
+
 ### v2.0.0
 
 - added Parser.getType() method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i18nlint-common",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "module": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/Result.js
+++ b/src/Result.js
@@ -95,7 +95,7 @@ class Result {
             fields.severity :
             "warning";
         ["description", "pathName", "rule", "id", "highlight", "lineNumber", "locale", "source"].forEach(property => {
-            if (fields[property]) this[property] = fields[property];
+            if (typeof(fields[property]) !== 'undefined') this[property] = fields[property];
         });
     }
 }

--- a/test/testResult.js
+++ b/test/testResult.js
@@ -78,6 +78,29 @@ export const testResult = {
         test.done();
     },
 
+    testResultLineZero: function(test) {
+        test.expect(2);
+
+        const result = new Result({
+            severity: "warning",
+            pathName: "a/b/c.js",
+            description: "test",
+            id: "x",
+            highlight: "test<e0/>",
+            lineNumber: 23,
+            charNumber: 14,
+            locale: "de-DE",
+            rule,
+            lineNumber: 0
+        });
+
+        test.ok(result);
+
+        test.equal(result.lineNumber, 0);
+
+        test.done();
+    },
+
     testResultNormalizeSeverity: function(test) {
         test.expect(4);
 


### PR DESCRIPTION
- fix a problem where you could not create a Result instance with a lineNumber equal to 0.
- problem was that the constructor was testing for a truthy lineNumber property and the value 0 doesn't work of course