### PR TITLE
Rename project from i18nlint-common to ilib-lint-common

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>i18nlint-common</name>
+	<name>ilib-lint-common</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# i18nlint-common
+# ilib-lint-common
 
 Common ilib-lint routines that the plugins will need.
 
@@ -6,11 +6,11 @@ Common ilib-lint routines that the plugins will need.
 ## Installation
 
 ```
-npm install i18nlint-common
+npm install ilib-lint-common
 
 or
 
-yarn add i18nlint-common
+yarn add ilib-lint-common
 ```
 
 This package is usually imported by the ilib-lint tool itself or plugins for
@@ -18,11 +18,11 @@ the ilib-lint tool.
 
 ## Full API Docs
 
-See the [full API docs](./docs/i18nlint-common.md) for more information.
+See the [full API docs](./docs/ilib-lint-common.md) for more information.
 
 ## License
 
-Copyright © 2022-2023, JEDLSoft
+Copyright © 2022-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v3.0.0
+
+- renamed from i18nlint-common to ilib-lint-common to go along with the name of
+  the tool
 
 ### v2.2.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "i18nlint-common",
-    "version": "2.2.1",
+    "name": "ilib-lint-common",
+    "version": "3.0.0",
     "module": "./src/index.js",
     "type": "module",
     "exports": {
@@ -19,8 +19,8 @@
         "lint",
         "locale"
     ],
-    "homepage": "https://github.com/iLib-js/i18nlint-common",
-    "bugs": "https://github.com/iLib-js/i18nlint-common/issues",
+    "homepage": "https://github.com/iLib-js/ilib-lint-common",
+    "bugs": "https://github.com/iLib-js/ilib-lint-common/issues",
     "email": "marketing@translationcircle.com",
     "license": "Apache-2.0",
     "author": {
@@ -46,7 +46,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/iLib-js/i18nlint-common.git"
+        "url": "https://github.com/iLib-js/ilib-lint-common.git"
     },
     "engines": {
         "node": ">=14.0.0"
@@ -61,7 +61,7 @@
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules ./node_modules/.bin/jest --watch",
         "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/.bin/jest -i",
         "clean": "git clean -f -d src test",
-        "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/i18nlint-common.md ; npm run doc:html",
+        "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilib-lint-common.md ; npm run doc:html",
         "doc:html": "jsdoc -c jsdoc.json",
         "types": "tsc -p ./jsconfig.json"
     },


### PR DESCRIPTION
- Clients will have to change their imports in order to use this, so therefore, this is a breaking change and we have to change the version number to 3.0.0.
- also, as you can see above, the git repo was renamed too

More changes to come before we publish 3.0.0